### PR TITLE
fix(regulation-tools): Defer inital value setting

### DIFF
--- a/packages/api-server/package.json
+++ b/packages/api-server/package.json
@@ -31,7 +31,7 @@
     "@aws-sdk/s3-presigned-post": "^3.53.1",
     "@elastic/elasticsearch": "^7.15.0",
     "@hugsmidjan/qj": "^4.10.2",
-    "@island.is/regulations-tools": "^0.7.13",
+    "@island.is/regulations-tools": "^0.7.14",
     "@types/express": "^4.17.13",
     "@types/ioredis": "^4.28.1",
     "@types/multer-s3-transform": "npm:@types/multer-s3@^2.7.10",

--- a/packages/tools/CHANGELOG.md
+++ b/packages/tools/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Upcoming...
 
+## 0.7.14
+
+- Defer inital value for initalvalue different from base value rendering
+
 ## 0.7.13
 
 _2024-01-16_

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@island.is/regulations-tools",
-  "version": "0.7.13",
+  "version": "0.7.14",
   "description": "Editing tools for Reglugerðir",
   "author": "Hugsmiðjan ehf. (www.hugsmidjan.is)",
   "contributors": [

--- a/packages/tools/src/Editor.tsx
+++ b/packages/tools/src/Editor.tsx
@@ -300,8 +300,10 @@ export const Editor = (
                     props.baseText && props.baseText !== initialText
                       ? 'ready'
                       : 'running';
-
-                  editor.setContent(initialText);
+                  setTimeout(() => {
+                    // Needs updating after render
+                    editor.setContent(initialText);
+                  }, 100);
                 }}
                 initialValue={baseText || initialText}
                 onFocus={props.onFocus}


### PR DESCRIPTION
When initial value of regulation editor is not the same as base, the value needs to be deferred so the diff changes can work their magic.