### PR TITLE
chore(api-server): Remove page number from PDF

### DIFF
--- a/packages/api-server/src/RegulationPdf.css
+++ b/packages/api-server/src/RegulationPdf.css
@@ -97,11 +97,11 @@
     @bottom-left {
       content: element(footerInfo);
     }
-    @bottom-right {
+    /* @bottom-right {
       content: 'Bls. ' counter(page) ' af ' counter(pages);
       font-size: 10pt;
       font-style: italic;
-    }
+    } */
   }
 
   * {


### PR DESCRIPTION
### What
Remove page number from PDF


### Why

Requested, so people will not reference articles or sections by page numbers. 